### PR TITLE
Updated JGit to a version that has a patched HttpClient

### DIFF
--- a/pom-explorer-core/pom.xml
+++ b/pom-explorer-core/pom.xml
@@ -94,7 +94,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>4.0.1.201506240215-r</version>
+			<version>4.0.3.201509231615-r</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom-explorer/pom.xml
+++ b/pom-explorer/pom.xml
@@ -94,7 +94,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>4.0.1.201506240215-r</version>
+			<version>4.0.3.201509231615-r</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.lteconsulting</groupId>


### PR DESCRIPTION
It's likely a minor issue, but I realised that pom-explorer relies on a quite old version of JGit that uses a vulnerable version of HttpClient. See
- https://www.meterian.com/report/gh/ltearno/pom-explorer?hl=true
- https://github.com/eclipse/jgit/commit/510c865bad90f8710c3ebdabf03eff06ca5a38fa
- https://nvd.nist.gov/vuln/detail/CVE-2014-3577

The PR just replaces the vulnerable version with the latest version on the 4.0.x branch