### PR TITLE
 expose isExternal, isBuildable can be to narrow

### DIFF
--- a/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/PomAnalysis.java
+++ b/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/PomAnalysis.java
@@ -224,6 +224,7 @@ public class PomAnalysis
 				duplicatedProjects.add( project );
 				log.html( Tools.warningMessage( "trying to add a project which is duplicated: " + project + ", already inserted : " + duplicate ) );
 			}
+			//FIXME processProjectForCompleteness returns always true, are unresolvableProjects irrelevant?
 			else if( processProjectForCompleteness( project, pomFileLoader ) )
 			{
 				readyProjects.add( project );

--- a/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/Project.java
+++ b/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/Project.java
@@ -120,6 +120,10 @@ public class Project
 		return project;
 	}
 
+	public boolean isExternal(){
+		return isExternal;
+	}
+
 	public boolean isBuildable()
 	{
 		return !isExternal && pomFile.getParentFile().toPath().resolve( "src" ).toFile().exists();

--- a/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/model/Gav.java
+++ b/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/model/Gav.java
@@ -43,9 +43,7 @@ public class Gav
 		if( parts.length != 3 )
 			return null;
 
-		Gav gav = new Gav( parts[0], parts[1], parts[2] );
-
-		return gav;
+		return new Gav( parts[0], parts[1], parts[2] );
 	}
 
 	public Gav copyWithVersion( String version )

--- a/pom-explorer-core/src/test/java/fr/lteconsulting/pomexplorer/AnalyzerTest.java
+++ b/pom-explorer-core/src/test/java/fr/lteconsulting/pomexplorer/AnalyzerTest.java
@@ -207,9 +207,9 @@ public class AnalyzerTest
 		//arrange
 		Session session = new Session();
 		//act
-		runFullRecursiveAnalysis(session, "testSets/set07");
+		runFullRecursiveAnalysis(session, "testSets/set08");
 		//assert
-		assertProjects(session, 2);
+		assertProjects(session, 1);
 		assertDependencies(session, PROJECT_A, 1);
 
 		Project project = session.projects().forGav(Gav.parse("fr.lteconsulting:a:1.0-SNAPSHOT"));

--- a/pom-explorer-core/testSets/set05/a.pom
+++ b/pom-explorer-core/testSets/set05/a.pom
@@ -8,8 +8,7 @@
 	  <artifactId>b</artifactId>
 	  <version>1.0-SNAPSHOT</version>
   </parent>
-  
-  <groupId>fr.lteconsulting</groupId>
+
   <artifactId>a</artifactId>
   <version>1.0-SNAPSHOT</version>
   

--- a/pom-explorer-core/testSets/set10/a.pom
+++ b/pom-explorer-core/testSets/set10/a.pom
@@ -9,7 +9,6 @@
 	  <version>1.0-SNAPSHOT</version>
   </parent>
   
-  <groupId>fr.lteconsulting</groupId>
   <artifactId>a</artifactId>
   <version>1.0-SNAPSHOT</version>
   


### PR DESCRIPTION
I need to know whether a project comes from one of the directories I
analyse or was loaded through aether. isBuildable is to narrow in the
sense that a particular project isExternal but does not have a src
folder (e.g. a parent pom without any src) in which case isBuildable
returns false.