### PR TITLE
track exclusions on dependency

### DIFF
--- a/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/PomAnalysis.java
+++ b/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/PomAnalysis.java
@@ -310,7 +310,7 @@ public class PomAnalysis
 					Gav dependencyGav = new Gav( key.getGroupId(), key.getArtifactId(), rawDependency.getVs().getVersion() );
 
 					tx.addGav( dependencyGav );
-					tx.addRelation( new DependencyRelation( gav, dependencyGav, new Dependency(key.getGroupId(), key.getArtifactId(), rawDependency.getVs(), key.getClassifier(), key.getType() ) ) );
+					tx.addRelation( new DependencyRelation( gav, dependencyGav, new Dependency(key.getGroupId(), key.getArtifactId(), rawDependency.getVs(), key.getClassifier(), key.getType(), rawDependency.getExclusions()) ) );
 				}
 			}
 

--- a/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/Project.java
+++ b/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/Project.java
@@ -264,12 +264,16 @@ public class Project
 				{
 					DependencyKeyVersionAndScope keyVersionAndScope = interpolateDependencyKeyVersionAndScope( d, projects, log );
 					VersionScope versionScope = determineVersionScope( keyVersionAndScope, profiles, projects, log, keyVersionAndScope.key, true);
+					Set<GroupArtifact> exclusions = new HashSet<>();
+					addExclusions( projects, log, d, exclusions::add);
+
 					Dependency dependency = new Dependency(
 							keyVersionAndScope.key.getGroupId(),
 							keyVersionAndScope.key.getArtifactId(),
 							versionScope,
 							keyVersionAndScope.key.getClassifier(),
-							keyVersionAndScope.key.getType()
+							keyVersionAndScope.key.getType(),
+							exclusions
 					);
 
 					dependencyManagement.put( dependency.key(), dependency );
@@ -627,7 +631,7 @@ public class Project
 
 	private void addExclusions( ProjectContainer projects, Log log, org.apache.maven.model.Dependency d, ExclusionAdder exclusionAdder )
 	{
-		if( d.getExclusions() != null && !d.getExclusions().isEmpty() )
+		if( d.getExclusions() != null)
 		{
 			for( Exclusion exclusion : d.getExclusions() )
 			{

--- a/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/model/Dependency.java
+++ b/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/model/Dependency.java
@@ -1,7 +1,9 @@
 package fr.lteconsulting.pomexplorer.model;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.Set;
 
 import fr.lteconsulting.pomexplorer.graph.relation.Scope;
 
@@ -16,6 +18,7 @@ public class Dependency
 	private final String type;
 
 	private DependencyKey key;
+	private Set<GroupArtifact> exclusions;
 
 	public static final Comparator<Dependency> alphabeticalComparator = Comparator.comparing(Dependency::toString);
 
@@ -31,15 +34,19 @@ public class Dependency
 
 	public Dependency( String groupId, String artifactId, String version, Scope scope, String classifier, String type )
 	{
-		this(groupId, artifactId, version, null, scope, classifier, type);
+		this(groupId, artifactId, version, null, scope, classifier, type, Collections.emptySet());
 	}
 
 	public Dependency(String groupId, String artifactId, VersionScope vs, String classifier, String type)
 	{
-		this(groupId, artifactId, vs.getVersion(), vs.isVersionSelfManaged().orElse(null), vs.getScope(), classifier, type);
+		this(groupId, artifactId, vs, classifier, type, Collections.emptySet());
 	}
 
-	public Dependency(String groupId, String artifactId, String version, Boolean isVersionSelfManaged, Scope scope, String classifier, String type )
+	public Dependency(String groupId, String artifactId, VersionScope vs, String classifier, String type, Set<GroupArtifact> exclusions) {
+		this(groupId, artifactId, vs.getVersion(), vs.isVersionSelfManaged().orElse(null), vs.getScope(), classifier, type, exclusions);
+	}
+
+	public Dependency(String groupId, String artifactId, String version, Boolean isVersionSelfManaged, Scope scope, String classifier, String type, Set<GroupArtifact> exclusions)
 	{
 		this.groupId = groupId;
 		this.artifactId = artifactId;
@@ -48,6 +55,7 @@ public class Dependency
 		this.scope = scope == null ? Scope.COMPILE : scope;
 		this.classifier = classifier;
 		this.type = type == null ? "jar" : type;
+		this.exclusions = exclusions;
 	}
 
 	public DependencyKey key()
@@ -101,6 +109,11 @@ public class Dependency
 		return type;
 	}
 
+	public Set<GroupArtifact> getExclusions()
+	{
+		return exclusions;
+	}
+
 	@Override
 	public String toString()
 	{
@@ -124,6 +137,7 @@ public class Dependency
 		result = prime * result + ((scope == null) ? 0 : scope.hashCode());
 		result = prime * result + ((type == null) ? 0 : type.hashCode());
 		result = prime * result + ((version == null) ? 0 : version.hashCode());
+		result = prime * result + ((exclusions == null) ? 0 : exclusions.hashCode());
 		return result;
 	}
 
@@ -180,6 +194,13 @@ public class Dependency
 				return false;
 		}
 		else if( !version.equals( other.version ) )
+			return false;
+		if( exclusions == null )
+		{
+			if( other.exclusions != null )
+				return false;
+		}
+		else if( !exclusions.equals( other.exclusions ) )
 			return false;
 		return true;
 	}

--- a/pom-explorer-core/testSets/dependencyManagementWithExclusion/a.pom
+++ b/pom-explorer-core/testSets/dependencyManagementWithExclusion/a.pom
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.lteconsulting</groupId>
+    <artifactId>a</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>test project a</description>
+    <properties>
+        <cversion>1.0-SNAPSHOT</cversion>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>fr.lteconsulting</groupId>
+                <artifactId>b</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <scope>compile</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>fr.lteconsulting</groupId>
+                        <artifactId>d</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.lteconsulting</groupId>
+            <artifactId>b</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>fr.lteconsulting</groupId>
+            <artifactId>c</artifactId>
+            <version>${cversion}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom-explorer-core/testSets/dependencyManagementWithExclusion/b.pom
+++ b/pom-explorer-core/testSets/dependencyManagementWithExclusion/b.pom
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>fr.lteconsulting</groupId>
+  <artifactId>b</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  
+  <packaging>jar</packaging>
+
+  <description>test project b</description>
+
+  <dependencyManagement>
+    <dependencies>
+    <dependency>
+      <groupId>fr.lteconsulting</groupId>
+      <artifactId>d</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/pom-explorer-core/testSets/dependencyManagementWithExclusion/c.pom
+++ b/pom-explorer-core/testSets/dependencyManagementWithExclusion/c.pom
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.lteconsulting</groupId>
+    <artifactId>c</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>test project c</description>
+    <dependencies>
+        <dependency>
+            <groupId>fr.lteconsulting</groupId>
+            <artifactId>toto</artifactId>
+            <version>1.4-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom-explorer-core/testSets/dependencyManagementWithExclusion/d.pom
+++ b/pom-explorer-core/testSets/dependencyManagementWithExclusion/d.pom
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.lteconsulting</groupId>
+    <artifactId>toto</artifactId>
+	
+			<version>1.4-SNAPSHOT</version>
+    
+	<packaging>jar</packaging>
+    <description>test project d</description>
+	<properties>
+		<uyt>FKFJHFGKJFHGKFJHG</uyt>
+		<tutu>no...</tutu>
+	</properties>
+</project>

--- a/pom-explorer-core/testSets/dependencyWithExclusion/a.pom
+++ b/pom-explorer-core/testSets/dependencyWithExclusion/a.pom
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.lteconsulting</groupId>
+    <artifactId>a</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>test project a</description>
+    <properties>
+        <cversion>1.0-SNAPSHOT</cversion>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>fr.lteconsulting</groupId>
+            <artifactId>b</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>fr.lteconsulting</groupId>
+                    <artifactId>d</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>fr.lteconsulting</groupId>
+            <artifactId>c</artifactId>
+            <version>${cversion}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom-explorer-core/testSets/dependencyWithExclusion/b.pom
+++ b/pom-explorer-core/testSets/dependencyWithExclusion/b.pom
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>fr.lteconsulting</groupId>
+  <artifactId>b</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  
+  <packaging>jar</packaging>
+
+  <description>test project b</description>
+
+  <dependencyManagement>
+    <dependencies>
+    <dependency>
+      <groupId>fr.lteconsulting</groupId>
+      <artifactId>d</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/pom-explorer-core/testSets/dependencyWithExclusion/c.pom
+++ b/pom-explorer-core/testSets/dependencyWithExclusion/c.pom
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.lteconsulting</groupId>
+    <artifactId>c</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <description>test project c</description>
+    <dependencies>
+        <dependency>
+            <groupId>fr.lteconsulting</groupId>
+            <artifactId>toto</artifactId>
+            <version>1.4-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom-explorer-core/testSets/dependencyWithExclusion/d.pom
+++ b/pom-explorer-core/testSets/dependencyWithExclusion/d.pom
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.lteconsulting</groupId>
+    <artifactId>toto</artifactId>
+	
+			<version>1.4-SNAPSHOT</version>
+    
+	<packaging>jar</packaging>
+    <description>test project d</description>
+	<properties>
+		<uyt>FKFJHFGKJFHGKFJHG</uyt>
+		<tutu>no...</tutu>
+	</properties>
+</project>


### PR DESCRIPTION
Currently we do not have access to the exclusions from the graph. They
are collected in RawDependency and DependencyManagement but not added to
Dependency as such.