### PR TITLE
Update maven-core dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8

--- a/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/MavenResolver.java
+++ b/pom-explorer-core/src/main/java/fr/lteconsulting/pomexplorer/MavenResolver.java
@@ -55,7 +55,7 @@ public class MavenResolver
 		repositories = callMethod( mavenSession, "getRemoteRepositories" );
 		s = getField( mavenSession, "session" );
 		system = getField( mavenSession, "system" );
-		settings = getField( mavenSession, "settings" );
+		settings = getField(getField(mavenSession, "settingsManager"), "settings");
 		localRepositoryPath = getField( settings, "localRepository" );
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,20 +70,18 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
-                <version>3.1.0</version>
+                <version>3.6.3</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-depchain</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.4</version>
                 <type>pom</type>
             </dependency>
-            <!-- Should be upgraded but sadly MavenResolver depends on internal
-                 structure which has changed -->
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-                <version>2.1.1</version>
+                <version>3.1.4</version>
             </dependency>
             <dependency>
                 <groupId>fr.lteconsulting</groupId>


### PR DESCRIPTION
Due to a bug in plexus-utils, there is an ArrayIndexOutOfBoundsException
if a big pom file is analyzed with the new M2Eclipse syntax for specifying
lifecycle mapping metadata. The bug is already fixed in plexus-utils,
so only the maven-core and shrinkwrap-resolver* dependencies have to be
updated.